### PR TITLE
fix monitoring tools extraction

### DIFF
--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -8,26 +8,16 @@
       - libnet-ldap-perl
       - monitoring-plugins-contrib
 
-- name: Download Nagios plugins
-  get_url:
-    url: "{{ ltb_base_url }}{{ ltb_nagios_archive_name }}"
-    dest: "{{ ltb_dest_path }}"
-    mode: '0644'
-
-- name: Download Cacti plugins
-  get_url:
-    url: "{{ ltb_base_url }}{{ ltb_cacti_archive_name }}"
-    dest: "{{ ltb_dest_path }}"
-    mode: '0644'
-
 - name: extract Nagios archive
   ansible.builtin.unarchive:
-    src: "{{ ltb_dest_path }}/{{ ltb_nagios_archive_name }}"
-    dest: "{{ ltb_dest_path }}"
+    src: "{{ ltb_base_url }}/{{ ltb_nagios_archive_name }}"
+    dest: "{{ ltb_nagios_dest_path }}"
     remote_src: yes
+    extra_opts: "{{ ltb_nagios_unarchive_opts }}"
 
 - name: extract Cacti archive
   ansible.builtin.unarchive:
-    src: "{{ ltb_dest_path }}/{{ ltb_cacti_archive_name }}"
-    dest: "{{ ltb_dest_path }}"
+    src: "{{ ltb_base_url }}/{{ ltb_cacti_archive_name }}"
+    dest: "{{ ltb_cacti_dest_path }}"
     remote_src: yes
+    extra_opts: "{{ ltb_cacti_unarchive_opts }}"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -24,8 +24,10 @@
   ansible.builtin.unarchive:
     src: "{{ ltb_dest_path }}/{{ ltb_nagios_archive_name }}"
     dest: "{{ ltb_dest_path }}"
+    remote_src: yes
 
 - name: extract Cacti archive
   ansible.builtin.unarchive:
     src: "{{ ltb_dest_path }}/{{ ltb_cacti_archive_name }}"
     dest: "{{ ltb_dest_path }}"
+    remote_src: yes

--- a/tests/monitoring.yml
+++ b/tests/monitoring.yml
@@ -6,10 +6,13 @@
   remote_user: root
   vars:
     # destination path where to put monitoring and statistics tools
-    ltb_dest_path: "/usr/local/openldap/etc/openldap/"
-    ltb_base_url: "https://ltb-project.org/archives/"
+    ltb_base_url: "https://ltb-project.org/archives"
     ltb_nagios_archive_name: "ltb-project-nagios-plugins-0.8.tar.gz"
+    ltb_nagios_dest_path: "/usr/local/openldap/etc/openldap/"
+    ltb_nagios_unarchive_opts: ""
     ltb_cacti_archive_name: "ltb-project-cacti-plugins-0.3.tar.gz"
+    ltb_cacti_dest_path: "/usr/local/openldap/etc/openldap/"
+    ltb_cacti_unarchive_opts: ""
   tasks:
     - name: deploying monitoring and statistics tools from LTB (load tasks/monitoring.yml)
       include_role:


### PR DESCRIPTION
Fixes the error below:

```
TASK [ldaptoolbox.openldap : extract Nagios archive] ************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
fatal: [host]: FAILED! => {"changed": false, "msg": "Could not find or access '/usr/local/openldap/etc/openldap//ltb-project-nagios-plugins-0.8.tar.gz' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
```