### PR TITLE
Support rpm based targets plus data import  #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OpenLDAP
 ========
 
-Ansible role which installs and configures [LTB-Project](https://ltb-project.org/)'s OpenLDAP on Debian target.
+Ansible role which installs and configures [LTB-Project](https://ltb-project.org/)'s OpenLDAP on Debian, CentOS, Rocky and RHEL targets.
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OpenLDAP
 ========
 
-Ansible role which installs and configures [LTB-Project](https://ltb-project.org/)'s OpenLDAP.
+Ansible role which installs and configures [LTB-Project](https://ltb-project.org/)'s OpenLDAP on Debian target.
 
 Requirements
 ------------
@@ -12,7 +12,7 @@ Requirements
 Role Variables
 --------------
 
-You'll need to store the hash value for you admin passwords. You'll get it like this:
+You'll need to store the hash value for your admin passwords. You'll get it like this:
 
 ```
 /usr/local/openldap/sbin/slappasswd -o module-path="/usr/local/openldap/libexec/openldap" -o module-load="argon2" -h "{ARGON2}" -s "password"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,8 @@ ldaptoolbox_openldap_configuration_group: ldap
 ldaptoolbox_openldap_configuration_mode: 0600
 ldaptoolbox_openldap_sslgroup: ssl-cert
 
+ldaptoolbox_openldap_slapd_path: /usr/local/openldap
+
 # OpenLDAP LTB CLI command path
 ldaptoolbox_openldap_slapd_cli_cmd: /usr/local/openldap/sbin/slapd-cli
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -161,4 +161,11 @@ ldaptoolbox_openldap_overlay_refint_olcRefintNothing: "cn=nothing,{{ ldaptoolbox
 # Dynamic groups (dynlist)
 ldaptoolbox_openldap_overlay_dynlist_olcDlAttrSet: "groupOfURLs memberURL member+memberOf@groupOfNames*"
 
+#############
+# Data import
+#############
 
+ldaptoolbox_openldap_data_prefix: 'openldap-data'
+# if not defined the default population template will be used which is fine for test purposes
+# here a sample using current ansible host as source. ( might not work due to rights ).
+# ldaptoolbox_openldap_import_data_ldif:  '/var/backups/openldap/openldap-data-20230227112107.ldif'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -169,3 +169,8 @@ ldaptoolbox_openldap_data_prefix: 'openldap-data'
 # if not defined the default population template will be used which is fine for test purposes
 # here a sample using current ansible host as source. ( might not work due to rights ).
 # ldaptoolbox_openldap_import_data_ldif:  '/var/backups/openldap/openldap-data-20230227112107.ldif'
+
+# import certificats if needed, don't define them at all if no import is required.
+# ldaptoolbox_openldap_import_olcTLSCACertificateFile: ca-cert.pem
+# ldaptoolbox_openldap_import_olcTLSCertificateFile: ldaps-cert.pem
+# ldaptoolbox_openldap_import_olcTLSCertificateKeyFile: nantes-ldaps.key

--- a/tasks/ldaptoolbox-add-ppolicy.yml
+++ b/tasks/ldaptoolbox-add-ppolicy.yml
@@ -4,7 +4,7 @@
 - name: add generated ppolicy to data backup source
   blockinfile:
     path: "{{ ldaptoolbox_openldap_configuration_backup_dir }}/{{ ldaptoolbox_openldap_data_prefix }}-{{ ldaptoolbox_openldap_configuration_timestamp }}.ldif"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - ppolicy"
     block: "{{ lookup('ansible.builtin.template', './{{ ldaptoolbox_openldap_configuration_backup_dir }}/ppolicy.ldif') }}"
     create: yes
     state: present
-

--- a/tasks/ldaptoolbox-add-ppolicy.yml
+++ b/tasks/ldaptoolbox-add-ppolicy.yml
@@ -1,0 +1,10 @@
+################################################################################
+# add syncrepl account in target opendlap
+################################################################################
+- name: add generated ppolicy to data backup source
+  blockinfile:
+    path: "{{ ldaptoolbox_openldap_configuration_backup_dir }}/{{ ldaptoolbox_openldap_data_prefix }}-{{ ldaptoolbox_openldap_configuration_timestamp }}.ldif"
+    block: "{{ lookup('ansible.builtin.template', './{{ ldaptoolbox_openldap_configuration_backup_dir }}/ppolicy.ldif') }}"
+    create: yes
+    state: present
+

--- a/tasks/ldaptoolbox-add-syncrepl.yml
+++ b/tasks/ldaptoolbox-add-syncrepl.yml
@@ -4,6 +4,7 @@
 - name: add generated syncrepl account to backuped data
   blockinfile:
     path: "{{ ldaptoolbox_openldap_configuration_backup_dir }}/{{ ldaptoolbox_openldap_data_prefix }}-{{ ldaptoolbox_openldap_configuration_timestamp }}.ldif"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - syncrepl"
     block: "{{ lookup('ansible.builtin.template', './{{ ldaptoolbox_openldap_configuration_backup_dir }}/syncrepl.ldif') }}"
     create: yes
     state: present

--- a/tasks/ldaptoolbox-add-syncrepl.yml
+++ b/tasks/ldaptoolbox-add-syncrepl.yml
@@ -1,0 +1,10 @@
+################################################################################
+# add syncrepl account in target opendlap
+################################################################################
+- name: add generated syncrepl account to backuped data
+  blockinfile:
+    path: "{{ ldaptoolbox_openldap_configuration_backup_dir }}/{{ ldaptoolbox_openldap_data_prefix }}-{{ ldaptoolbox_openldap_configuration_timestamp }}.ldif"
+    block: "{{ lookup('ansible.builtin.template', './{{ ldaptoolbox_openldap_configuration_backup_dir }}/syncrepl.ldif') }}"
+    create: yes
+    state: present
+

--- a/tasks/ldaptoolbox-certificates.yml
+++ b/tasks/ldaptoolbox-certificates.yml
@@ -3,7 +3,7 @@
     name: "{{ ldaptoolbox_openldap_configuration_owner }}"
     groups: "{{ ldaptoolbox_openldap_sslgroup }}"
     state: present
-  when: ( ldaptoolbox_openldap_olcTLSCertificateFile is defined )
+  when: ( ldaptoolbox_openldap_olcTLSCertificateFile )
 
 - name: Ensure correct file ownership, group and permissions for CA
   ansible.builtin.file:
@@ -11,6 +11,7 @@
     owner: "root"
     group: "root"
     mode: "644"
+  when: ( ldaptoolbox_openldap_olcTLSCACertificateFile )
 
 - name: Ensure correct file ownership, group and permissions for certificate
   ansible.builtin.file:
@@ -18,6 +19,7 @@
     owner: "root"
     group: "root"
     mode: "644"
+  when: ( ldaptoolbox_openldap_olcTLSCertificateFile )
 
 - name: Ensure correct file ownership, group and permissions for key
   ansible.builtin.file:
@@ -25,3 +27,4 @@
     owner: "root"
     group: "{{ ldaptoolbox_openldap_sslgroup }}"
     mode: "640"
+  when: ( ldaptoolbox_openldap_olcTLSCertificateKeyFile )

--- a/tasks/ldaptoolbox-certificates.yml
+++ b/tasks/ldaptoolbox-certificates.yml
@@ -1,0 +1,27 @@
+- name: allow ldap to read TLS certificates
+  ansible.builtin.user:
+    name: "{{ ldaptoolbox_openldap_configuration_owner }}"
+    groups: "{{ ldaptoolbox_openldap_sslgroup }}"
+    state: present
+  when: ( ldaptoolbox_openldap_olcTLSCertificateFile is defined )
+
+- name: Ensure correct file ownership, group and permissions for CA
+  ansible.builtin.file:
+    path: "{{ ldaptoolbox_openldap_olcTLSCACertificateFile }}"
+    owner: "root"
+    group: "root"
+    mode: "644"
+
+- name: Ensure correct file ownership, group and permissions for certificate
+  ansible.builtin.file:
+    path: "{{ ldaptoolbox_openldap_olcTLSCertificateFile }}"
+    owner: "root"
+    group: "root"
+    mode: "644"
+
+- name: Ensure correct file ownership, group and permissions for key
+  ansible.builtin.file:
+    path: "{{ ldaptoolbox_openldap_olcTLSCertificateKeyFile }}"
+    owner: "root"
+    group: "{{ ldaptoolbox_openldap_sslgroup }}"
+    mode: "640"

--- a/tasks/ldaptoolbox-certificates.yml
+++ b/tasks/ldaptoolbox-certificates.yml
@@ -1,3 +1,29 @@
+- name: import TLS CA CertificateFile
+  copy:
+    src: "{{ ldaptoolbox_openldap_import_olcTLSCACertificateFile }}"
+    dest: "{{ ldaptoolbox_openldap_olcTLSCACertificateFile}}"
+    owner: "root"
+    group: "{{ ldaptoolbox_openldap_sslgroup }}"
+    mode: "644"
+  when: ldaptoolbox_openldap_import_olcTLSCACertificateFile is defined
+
+- name: import TLS CertificateFile
+  copy:
+    src: "{{ ldaptoolbox_openldap_import_olcTLSCertificateFile }}"
+    dest: "{{ ldaptoolbox_openldap_olcTLSCertificateFile}}"
+    group: "{{ ldaptoolbox_openldap_sslgroup }}"
+    mode: "644"
+  when: ldaptoolbox_openldap_import_olcTLSCertificateFile is defined
+
+- name: import TLS CertificateKeyFile
+  copy:
+    src: "{{ ldaptoolbox_openldap_import_olcTLSCertificateKeyFile }}"
+    dest: "{{ ldaptoolbox_openldap_olcTLSCertificateKeyFile}}"
+    owner: "root"
+    group: "{{ ldaptoolbox_openldap_sslgroup }}"
+    mode: "640"
+  when: ldaptoolbox_openldap_import_olcTLSCertificateKeyFile is defined
+
 - name: allow ldap to read TLS certificates
   ansible.builtin.user:
     name: "{{ ldaptoolbox_openldap_configuration_owner }}"

--- a/tasks/ldaptoolbox-repository.yml
+++ b/tasks/ldaptoolbox-repository.yml
@@ -17,3 +17,31 @@
   when:
   - ansible_os_family == "Debian"
 
+
+- name: centos repository
+  block:
+
+  - name: fetch repository key
+    ansible.builtin.shell: "rpm --import https://ltb-project.org/documentation/_static/RPM-GPG-KEY-LTB-project"
+
+  - name: setup epel repository
+    ansible.builtin.shell: |
+      dnf config-manager --set-enabled powertools
+      dnf install -y epel-release epel-next-release
+
+  - name: "setup ldaptoolbox repository on centos"
+    copy:
+      content: |
+        [ltb-project]
+        name=LTB project packages
+        baseurl=https://ltb-project.org/rpm/openldap25/$releasever/$basearch
+        enabled=1
+        gpgcheck=1
+        gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project
+      dest: /etc/yum.repos.d/ltb-project.repo
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "8")
+
+
+- name: "unsupported distribution check"
+  ansible.builtin.shell: "echo '{{ ansible_distribution }} {{ ansible_distribution_major_version }} ' > /root/ansible_vars"
+  when: not ( (ansible_os_family == "Debian") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "8") )

--- a/tasks/ldaptoolbox-repository.yml
+++ b/tasks/ldaptoolbox-repository.yml
@@ -7,13 +7,12 @@
   - name: fetch repository key
     ansible.builtin.shell: "curl {{ ldaptoolbox_openldap_apt_key_url }} | gpg --dearmor > {{ ldaptoolbox_openldap_apt_keyrings_path }}/{{ ldaptoolbox_openldap_apt_repo_filename }}.gpg"
 
-  - name: add repository
+  - name: add debian repository
     ansible.builtin.apt_repository:
       repo: "{{ ldaptoolbox_openldap_apt_repo }}"
       filename: "{{ ldaptoolbox_openldap_apt_repo_filename }}"
       update_cache: yes
       state: present
-
   when:
   - ansible_os_family == "Debian"
 
@@ -29,7 +28,7 @@
       dnf config-manager --set-enabled powertools
       dnf install -y epel-release epel-next-release
 
-  - name: "setup ldaptoolbox repository on centos"
+  - name: "setup ldaptoolbox repository on redhat / centos / rocky "
     copy:
       content: |
         [ltb-project]
@@ -39,8 +38,7 @@
         gpgcheck=1
         gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project
       dest: /etc/yum.repos.d/ltb-project.repo
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "8")
-
+  when: ( ((ansible_distribution == "CentOS")  or (ansible_distribution == "Rocky") or (ansible_distribution == 'Red Hat Enterprise Linux' )) and ( ( ansible_distribution_major_version == "8" ) or ( ansible_distribution_major_version == "9" ) ) )
 
 - name: "unsupported distribution check"
   ansible.builtin.shell: "echo '{{ ansible_distribution }} {{ ansible_distribution_major_version }} ' > /root/ansible_vars"

--- a/tasks/ldaptoolbox-repository.yml
+++ b/tasks/ldaptoolbox-repository.yml
@@ -38,7 +38,7 @@
         gpgcheck=1
         gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project
       dest: /etc/yum.repos.d/ltb-project.repo
-  when: ( ((ansible_distribution == "CentOS")  or (ansible_distribution == "Rocky") or (ansible_distribution == 'Red Hat Enterprise Linux' )) and ( ( ansible_distribution_major_version == "8" ) or ( ansible_distribution_major_version == "9" ) ) )
+  when: ( ((ansible_distribution == "CentOS")  or (ansible_distribution == "Rocky") or (ansible_distribution == 'RedHat' )) and ( ( ansible_distribution_major_version == "8" ) or ( ansible_distribution_major_version == "9" ) ) )
 
 - name: "unsupported distribution check"
   ansible.builtin.shell: "echo '{{ ansible_distribution }} {{ ansible_distribution_major_version }} ' > /root/ansible_vars"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
 
 - name: build generated data from template
   ansible.builtin.shell: "{{ ldaptoolbox_openldap_slapd_cli_cmd }} importdatatemplate"
-  when: not ldaptoolbox_openldap_import_data_ldif is defined
+  when: ldaptoolbox_openldap_generate_data_ldif is defined
 
 # Import Data
 # -----------
@@ -70,6 +70,10 @@
 
 - name: add syncrepl account
   include_tasks: ldaptoolbox-add-syncrepl.yml
+  when: ldaptoolbox_openldap_import_data_ldif is defined
+
+- name: add default ppolicy pwdPolicy
+  include_tasks: ldaptoolbox-add-ppolicy.yml
   when: ldaptoolbox_openldap_import_data_ldif is defined
 
 - name: restore data

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,4 +78,4 @@
 
 - name: restore data
   ansible.builtin.shell: "{{ ldaptoolbox_openldap_slapd_cli_cmd }} restore"
-
+  when: ( ldaptoolbox_openldap_import_data_ldif is defined ) or ( ldaptoolbox_openldap_generate_data_ldif is defined )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,8 +22,6 @@
 
 - name: setup certificates
   include_tasks: ldaptoolbox-certificates.yml
-  when: ( ansible_os_family == "Debian")
-
 
 # Configuration
 # -------------
@@ -36,6 +34,14 @@
     group: "{{ ldaptoolbox_openldap_configuration_group }}"
     mode: "{{ ldaptoolbox_openldap_configuration_mode }}"
 
+- name: deploy sladp-cli file
+  ansible.builtin.template:
+    src: "./usr/local/openldap/etc/openldap/slapd-cli.conf"
+    dest: "/usr/local/openldap/etc/openldap/slapd-cli.conf"
+    owner: "root"
+    group: "root"
+    mode: "644"
+
 - name: deploy custom schema
   ansible.builtin.template:
     src: "{{ ldaptoolbox_openldap_custom_schema_srcdir }}/{{ item }}"
@@ -46,6 +52,9 @@
 
 - name: load config from file
   ansible.builtin.shell: "{{ ldaptoolbox_openldap_slapd_cli_cmd }} restoreconfig"
+
+- name: build generated data from template
+  ansible.builtin.shell: "{{ ldaptoolbox_openldap_slapd_cli_cmd }} importdatatemplate"
 
 # Import Data
 # -----------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,9 +55,20 @@
 
 - name: build generated data from template
   ansible.builtin.shell: "{{ ldaptoolbox_openldap_slapd_cli_cmd }} importdatatemplate"
+  when: not ldaptoolbox_openldap_import_data_ldif is defined
 
 # Import Data
 # -----------
 
-#TODO
+- name: import data ldif provided
+  copy:
+    src: "{{ ldaptoolbox_openldap_import_data_ldif }}"
+    dest: "{{ ldaptoolbox_openldap_configuration_backup_dir }}/{{ ldaptoolbox_openldap_data_prefix }}-{{ ldaptoolbox_openldap_configuration_timestamp }}.ldif"
+    owner: "{{ ldaptoolbox_openldap_configuration_owner }}"
+    group: "{{ ldaptoolbox_openldap_configuration_group }}"
+    mode: "{{ ldaptoolbox_openldap_configuration_mode }}"
+  when: ldaptoolbox_openldap_import_data_ldif is defined
+
+- name: restore data
+  ansible.builtin.shell: "{{ ldaptoolbox_openldap_slapd_cli_cmd }} restore"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,6 @@
     name: "{{ ldaptoolbox_openldap_packages_base }}"
     state: "{{ ldaptoolbox_openldap_packages_state }}"
 
-
 - name: setup certificates
   include_tasks: ldaptoolbox-certificates.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,6 +68,10 @@
     mode: "{{ ldaptoolbox_openldap_configuration_mode }}"
   when: ldaptoolbox_openldap_import_data_ldif is defined
 
+- name: add syncrepl account
+  include_tasks: ldaptoolbox-add-syncrepl.yml
+  when: ldaptoolbox_openldap_import_data_ldif is defined
+
 - name: restore data
   ansible.builtin.shell: "{{ ldaptoolbox_openldap_slapd_cli_cmd }} restore"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,8 @@
   package:
     name: "{{ ldaptoolbox_openldap_packages_dependencies }}"
     state: "{{ ldaptoolbox_openldap_packages_state }}"
+  when:
+  - ansible_os_family == "Debian"
 
 - name: install ldaptoolbox repository
   include_tasks: ldaptoolbox-repository.yml
@@ -17,33 +19,11 @@
     name: "{{ ldaptoolbox_openldap_packages_base }}"
     state: "{{ ldaptoolbox_openldap_packages_state }}"
 
-- name: allow ldap to read TLS certificates
-  ansible.builtin.user:
-    name: "{{ ldaptoolbox_openldap_configuration_owner }}"
-    groups: "{{ ldaptoolbox_openldap_sslgroup }}"
-    state: present
-  when: ldaptoolbox_openldap_olcTLSCertificateFile is defined
 
-- name: Ensure correct file ownership, group and permissions for CA
-  ansible.builtin.file:
-    path: "{{ ldaptoolbox_openldap_olcTLSCACertificateFile }}"
-    owner: "root"
-    group: "root"
-    mode: "644"
+- name: setup certificates
+  include_tasks: ldaptoolbox-certificates.yml
+  when: ( ansible_os_family == "Debian")
 
-- name: Ensure correct file ownership, group and permissions for certificate
-  ansible.builtin.file:
-    path: "{{ ldaptoolbox_openldap_olcTLSCertificateFile }}"
-    owner: "root"
-    group: "root"
-    mode: "644"
-
-- name: Ensure correct file ownership, group and permissions for key
-  ansible.builtin.file:
-    path: "{{ ldaptoolbox_openldap_olcTLSCertificateKeyFile }}"
-    owner: "root"
-    group: "{{ ldaptoolbox_openldap_sslgroup }}"
-    mode: "640"
 
 # Configuration
 # -------------

--- a/templates/usr/local/openldap/etc/openldap/slapd-cli.conf
+++ b/templates/usr/local/openldap/etc/openldap/slapd-cli.conf
@@ -1,0 +1,118 @@
+#====================================================================
+# Configuration example of OpenLDAP's init script
+#====================================================================
+
+# Networking parameters
+IP="*"
+PORT="389"
+SSLIP="*"
+SSLPORT="636"
+LDAPI_SOCKETDIR="/var/run/slapd"
+LDAPI_SOCKETURL="%2Fvar%2Frun%2Fslapd%2Fldapi"
+SLAPD_SERVICES="ldap://$IP:$PORT {% if ldaptoolbox_openldap_olcTLSCertificateFile %}ldaps://$SSLIP:$SSLPORT{% endif %} ldapi://$LDAPI_SOCKETURL"
+
+# OpenLDAP directories and files
+SLAPD_PATH="{{ ldaptoolbox_openldap_slapd_path }}"
+DATA_PATH="auto"
+SLAPD_PID_FILE="$SLAPD_PATH/var/run/slapd.pid"
+SLAPD_CONF="$SLAPD_PATH/etc/openldap/slapd.conf"
+SLAPD_CONF_DIR="$SLAPD_PATH/etc/openldap/slapd.d"
+SLAPD_BIN="$SLAPD_PATH/libexec/slapd"
+SLAPD_PARAMS=""
+SLAPD_MODULEDIR="$SLAPD_PATH/libexec/openldap"
+SLAPADD_BIN="$SLAPD_PATH/sbin/slapadd"
+SLAPADD_PARAMS="-q"
+SLAPCAT_BIN="$SLAPD_PATH/sbin/slapcat"
+SLAPCAT_PARAMS="-o ldif-wrap=no"
+SLAPINDEX_BIN="$SLAPD_PATH/sbin/slapindex"
+SLAPTEST_BIN="$SLAPD_PATH/sbin/slaptest"
+LDAPSEARCH_BIN="${SLAPD_PATH}/bin/ldapsearch"
+
+# Other options for slapd launch
+SLAPD_USER="{{ ldaptoolbox_openldap_configuration_owner }}"
+SLAPD_GROUP="{{ ldaptoolbox_openldap_configuration_group }}"
+SLAPD_SYSLOG_LOCAL_USER="local4"
+TIMEOUT="30" # Max time to stop process
+FD_LIMIT="1024" # Max file descriptor
+DEBUG_LEVEL="256" # Debug loglevel
+TOLERANCE_CSN=1000000 # 1s of tolerance when comparing contextCSN
+
+SLAPD_VERSION="2.5" # OpenLDAP version: major.minor (don't include .patch)
+
+# Backup
+BACKUP_AT_SHUTDOWN="0"
+BACKUP_PATH="{{ ldaptoolbox_openldap_configuration_backup_dir }}"
+BACKUP_SUFFIX="`date +%Y%m%d%H%M%S`.ldif"
+BACKUP_COMPRESS_EXT="" # gz, bz2, ...
+BACKUP_COMPRESS_BIN="" # /bin/gzip, /bin/bzip2, ...
+BACKUP_UNCOMPRESS_BIN="" # /bin/gunzip, /bin/bunzip2, ...
+UMASK="umask"
+MASK="0027"
+
+# Services
+SYSTEMD_SERVICE_NAME=slapd-ltb
+SYSTEMD_LLOAD_SERVICE_NAME=lload-ltb
+
+# Data provisioning
+DATA_TEMPLATE_FILE="data-template-${SLAPD_VERSION}.ldif"
+DATA_SUFFIX="{{ ldaptoolbox_openldap_suffix }}"
+DATA_ORGANIZATION="My Organization"
+DATA_SERVICEACCOUNT_DN="cn=my-account,ou=accounts,ou=infrastructure,${DATA_SUFFIX}"
+DATA_SERVICEACCOUNT_PW="secret"
+# Add automatically any number of admins and users
+# syntax for admins: DATA_ADMIN_<USER>_<ATTR>
+# syntax for users: DATA_USER_<USER>_<ATTR>
+# where <ATTR> is one of DN, PW, UID, SN, GN or MAIL
+# and <USER> is any unique value (not used for provisionning)
+DATA_ADMIN_DJACKSON_DN="uid=daniel.jackson,ou=people,${DATA_SUFFIX}"
+DATA_ADMIN_DJACKSON_PW="secret"
+DATA_ADMIN_DJACKSON_UID="daniel.jackson"
+DATA_ADMIN_DJACKSON_SN="Jackson"
+DATA_ADMIN_DJACKSON_GN="Daniel"
+DATA_ADMIN_DJACKSON_MAIL="daniel.jackson@my-example.com"
+DATA_USER_JONEILL_DN="uid=jack.oneill,ou=people,${DATA_SUFFIX}"
+DATA_USER_JONEILL_PW="secret"
+DATA_USER_JONEILL_UID="jack.oneill"
+DATA_USER_JONEILL_SN="O Neill"
+DATA_USER_JONEILL_GN="Jack"
+DATA_USER_JONEILL_MAIL="jack.oneill@my-example.com"
+DATA_USER_SCARTER_DN="uid=samantha.carter,ou=people,${DATA_SUFFIX}"
+DATA_USER_SCARTER_PW="secret"
+DATA_USER_SCARTER_UID="samantha.carter"
+DATA_USER_SCARTER_SN="Carter"
+DATA_USER_SCARTER_GN="Samantha"
+DATA_USER_SCARTER_MAIL="samantha.carter@my-example.com"
+DATA_USER_TEALC_DN="uid=tealc,ou=people,${DATA_SUFFIX}"
+DATA_USER_TEALC_PW="secret"
+DATA_USER_TEALC_UID="tealc"
+DATA_USER_TEALC_SN="Jaffa"
+DATA_USER_TEALC_GN="TealC"
+DATA_USER_TEALC_MAIL="tealc@my-example.com"
+DATA_ORGANIZATIONS="SG1,SG2"
+
+# Config provisioning
+CONFIG_FLAT_TEMPLATE_FILE="config-template-${SLAPD_VERSION}.conf"
+CONFIG_LDIF_TEMPLATE_FILE="config-template-${SLAPD_VERSION}.ldif"
+CONFIG_SUFFIX="dc=my-domain,dc=com"
+CONFIG_FQDN="ldap.my-domain.com"
+CONFIG_LOGLEVEL="256"
+CONFIG_LOGFILE="/var/log/slapd-ltb/slapd.log"
+CONFIG_MANAGERROOTDN="cn=Manager,dc=my-domain,dc=com"
+CONFIG_MANAGERROOTPW="secret"
+CONFIG_CONFIGROOTDN="cn=config"
+CONFIG_CONFIGROOTPW="secret"
+CONFIG_MONITORROOTDN="cn=monitor"
+CONFIG_MONITORROOTPW="secret"
+CONFIG_DATADIR="${SLAPD_PATH}/var/openldap-data"
+
+# lload
+LLOAD_IP="*"
+LLOAD_PORT="3389"
+LLOAD_SSLIP="*"
+LLOAD_SSLPORT="6636"
+LLOAD_SOCKETURL="%2Fvar%2Frun%2Fslapd%2Flload"
+LLOAD_SERVICES="ldap://${LLOAD_IP}:${LLOAD_PORT} {% if ldaptoolbox_openldap_olcTLSCertificateFile %}ldaps://${LLOAD_SSLIP}:${LLOAD_SSLPORT}{% endif %} ldapi://$LLOAD_SOCKETURL"
+LLOAD_PID_FILE="$SLAPD_PATH/var/run/lload.pid"
+LLOAD_CONF="$SLAPD_PATH/etc/openldap/lload.conf"
+LLOAD_CONF_DIR=""
+

--- a/templates/var/backups/openldap/config.ldif
+++ b/templates/var/backups/openldap/config.ldif
@@ -17,7 +17,8 @@ olcIndexSubstrAnyLen: 4
 olcIndexSubstrAnyStep: 2
 olcIndexIntLen: 4
 olcListenerThreads: 1
-olcLocalSSF: 71
+# olcLocalSSF: 71 , allow ldapi access, make it >= olcSecurity ssf
+olcLocalSSF: 128
 olcPidFile: /usr/local/openldap/var/run/slapd.pid
 olcReadOnly: FALSE
 olcSaslHost: {{ ldaptoolbox_openldap_olcSaslHost }}
@@ -26,12 +27,16 @@ olcServerID: {{ ldaptoolbox_openldap_olcServerID }}
 olcSockbufMaxIncoming: 262143
 olcSockbufMaxIncomingAuth: 16777215
 olcThreads: 16
+{% if ldaptoolbox_openldap_olcTLSCACertificateFile %}
 olcTLSCACertificateFile: {{ ldaptoolbox_openldap_olcTLSCACertificateFile }}
-olcTLSCertificateFile:  {{ ldaptoolbox_openldap_olcTLSCertificateFile }}
-olcTLSCertificateKeyFile: {{ ldaptoolbox_openldap_olcTLSCertificateKeyFile }}
 olcTLSCRLCheck: none
 olcTLSVerifyClient: allow
 olcTLSProtocolMin: {{ ldaptoolbox_openldap_olcTLSProtocolMin }}
+{% endif %}
+{% if ldaptoolbox_openldap_olcTLSCertificateFile %}
+olcTLSCertificateFile:  {{ ldaptoolbox_openldap_olcTLSCertificateFile }}
+olcTLSCertificateKeyFile: {{ ldaptoolbox_openldap_olcTLSCertificateKeyFile }}
+{% endif %}
 olcToolThreads: 1
 olcWriteTimeout: 0
 olcLogLevel: {{ ldaptoolbox_openldap_olcLogLevel }}
@@ -84,7 +89,7 @@ olcSortVals: {{ ldaptoolbox_openldap_olcSortVals }}
 dn: olcDatabase={0}config,cn=config
 objectClass: olcDatabaseConfig
 olcDatabase: {0}config
-olcAccess: {0}to *  by * none
+olcAccess: {0} to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * none
 olcAddContentAcl: TRUE
 olcLastMod: TRUE
 olcMaxDerefDepth: 15
@@ -111,7 +116,7 @@ olcRootPW: {{ ldaptoolbox_openldap_database_olcRootPW_hash }}
 olcSyncUseSubentry: FALSE
 olcLastBind: TRUE
 {% for syncrepl in ldaptoolbox_openldap_syncrepl %}
-olcSyncrepl: rid={{ syncrepl.rid }} provider={{ syncrepl.provider }} bindmethod=simple timeout=0 network-timeout=0 binddn="{{ syncrepl.binddn }}" credentials="{{ syncrepl.password }}" keepalive=0:0:0 starttls=no {% if syncrepl.tlscert %}tls_cert="{{ syncrepl.tlscert }}" tls_key={{ syncrepl.tlskey }}" tls_cacert="{{ syncrepl.tlscacert }}" tls_reqcert="{{ syncrepl.tlsreqcert }}"{% endif %} filter="(objectclass=*)" searchbase="{{ syncrepl.searchbase }}" scope="{{ syncrepl.scope }}" schemachecking=on type="{{ syncrepl.type }}" retry="{{ syncrepl.retry }}"
+olcSyncrepl: rid={{ syncrepl.rid }} provider={{ syncrepl.provider }} bindmethod=simple timeout=0 network-timeout=0 binddn="{{ syncrepl.binddn }}" credentials="{{ syncrepl.password }}" keepalive=0:0:0 starttls=no {% if syncrepl.tlscert %}tls_cert="{{ syncrepl.tlscert }}" tls_key="{{ syncrepl.tlskey }}" tls_cacert="{{ syncrepl.tlscacert }}" tls_reqcert="{{ syncrepl.tlsreqcert }}"{% endif %} filter="(objectclass=*)" searchbase="{{ syncrepl.searchbase }}" scope="{{ syncrepl.scope }}" schemachecking=on type="{{ syncrepl.type }}" retry="{{ syncrepl.retry }}"
 {% endfor %}
 {% if ldaptoolbox_openldap_syncrepl|length > 0 %}
 olcMultiProvider: TRUE

--- a/templates/var/backups/openldap/config.ldif
+++ b/templates/var/backups/openldap/config.ldif
@@ -94,8 +94,10 @@ olcAddContentAcl: TRUE
 olcLastMod: TRUE
 olcMaxDerefDepth: 15
 olcReadOnly: FALSE
+{% if ldaptoolbox_openldap_config_olcRootDN %}
 olcRootDN: {{ ldaptoolbox_openldap_config_olcRootDN }}
 olcRootPW: {{ ldaptoolbox_openldap_config_olcRootPW_hash }}
+{% endif %}
 olcSyncUseSubentry: FALSE
 olcMonitoring: FALSE
 
@@ -105,6 +107,14 @@ objectClass: olcMdbConfig
 olcDatabase: {1}mdb
 olcDbDirectory: /usr/local/openldap/var/openldap-data
 olcSuffix: {{ ldaptoolbox_openldap_suffix }}
+{% if ldaptoolbox_openldap_database_olcAccess|length > 0 %}
+{% for olcaccess in ldaptoolbox_openldap_database_olcAccess %}
+olcAccess: {{olcaccess.to}}
+{% for by in olcaccess.by %}
+  by {{by}}
+{% endfor %}
+{% endfor %}
+{% endif %}
 olcLastMod: TRUE
 {% for limit in ldaptoolbox_openldap_database_olcLimits %}
 olcLimits: {{ limit }}
@@ -118,10 +128,14 @@ olcLastBind: TRUE
 {% for syncrepl in ldaptoolbox_openldap_syncrepl %}
 olcSyncrepl: rid={{ syncrepl.rid }} provider={{ syncrepl.provider }} bindmethod=simple timeout=0 network-timeout=0 binddn="{{ syncrepl.binddn }}" credentials="{{ syncrepl.password }}" keepalive=0:0:0 starttls=no {% if syncrepl.tlscert %}tls_cert="{{ syncrepl.tlscert }}" tls_key="{{ syncrepl.tlskey }}" tls_cacert="{{ syncrepl.tlscacert }}" tls_reqcert="{{ syncrepl.tlsreqcert }}"{% endif %} filter="(objectclass=*)" searchbase="{{ syncrepl.searchbase }}" scope="{{ syncrepl.scope }}" schemachecking=on type="{{ syncrepl.type }}" retry="{{ syncrepl.retry }}"
 {% endfor %}
-{% if ldaptoolbox_openldap_syncrepl|length > 0 %}
+{% if ldaptoolbox_openldap_syncrepl|length > 1 %}
 olcMultiProvider: TRUE
 {% endif %}
+{% if ldaptoolbox_openldap_monitor_olcRootDN %}
 olcMonitoring: TRUE
+{% else %}
+olcMonitoring: FALSE
+{% endif %}
 {% for index in ldaptoolbox_openldap_database_olcDbIndexes %}
 olcDbIndex: {{ index }}
 {% endfor %}
@@ -155,6 +169,7 @@ objectClass: olcDynamicList
 olcOverlay: {3}dynlist
 olcDlAttrSet: {{ ldaptoolbox_openldap_overlay_dynlist_olcDlAttrSet }}
 
+{% if ldaptoolbox_openldap_monitor_olcRootDN %}
 dn: olcDatabase={2}monitor,cn=config
 objectClass: olcDatabaseConfig
 olcDatabase: {2}monitor
@@ -166,4 +181,4 @@ olcMaxDerefDepth: 15
 olcReadOnly: FALSE
 olcSyncUseSubentry: FALSE
 olcMonitoring: FALSE
-
+{% endif %}

--- a/templates/var/backups/openldap/ppolicy.ldif
+++ b/templates/var/backups/openldap/ppolicy.ldif
@@ -1,0 +1,26 @@
+dn: ou=ppolicies,{{ ldaptoolbox_openldap_suffix }}
+ou: ppolicies
+objectClass: organizationalUnit
+
+
+dn: cn=default,ou=ppolicies,{{ ldaptoolbox_openldap_suffix }}
+objectClass: pwdPolicy
+objectClass: device
+objectClass: top
+cn: default
+pwdAttribute: userPassword
+pwdMinAge: 0
+pwdMaxAge: 31536000
+pwdMinLength: 14
+pwdInHistory: 5
+pwdMaxFailure: 10
+pwdFailureCountInterval: 300
+pwdLockout: TRUE
+pwdLockoutDuration: 60
+pwdAllowUserChange: TRUE
+pwdExpireWarning: 864000
+pwdGraceAuthNLimit: 0
+pwdMustChange: TRUE
+pwdSafeModify: FALSE
+pwdCheckQuality: 1
+

--- a/templates/var/backups/openldap/ppolicy.ldif
+++ b/templates/var/backups/openldap/ppolicy.ldif
@@ -1,7 +1,7 @@
+
 dn: ou=ppolicies,{{ ldaptoolbox_openldap_suffix }}
 ou: ppolicies
 objectClass: organizationalUnit
-
 
 dn: cn=default,ou=ppolicies,{{ ldaptoolbox_openldap_suffix }}
 objectClass: pwdPolicy

--- a/templates/var/backups/openldap/syncrepl.ldif
+++ b/templates/var/backups/openldap/syncrepl.ldif
@@ -1,3 +1,4 @@
+
 dn: ou=infrastructure,{{ ldaptoolbox_openldap_suffix }}
 ou: infrastructure
 objectClass: organizationalUnit
@@ -16,3 +17,4 @@ userPassword: {{ ldaptoolbox_openldap_syncrepl_password_hash }}
 userPassword: {{ ldaptoolbox_openldap_syncrepl_password_vault }}
 {% endif %}
 # pwdPolicySubentry: cn=dsa,ou=ppolicies,{{ ldaptoolbox_openldap_suffix }}
+

--- a/templates/var/backups/openldap/syncrepl.ldif
+++ b/templates/var/backups/openldap/syncrepl.ldif
@@ -1,0 +1,18 @@
+dn: ou=infrastructure,{{ ldaptoolbox_openldap_suffix }}
+ou: infrastructure
+objectClass: organizationalUnit
+
+dn: ou=accounts,ou=infrastructure,{{ ldaptoolbox_openldap_suffix }}
+ou: accounts
+objectClass: organizationalUnit
+
+dn: uid=syncrepl,ou=accounts,ou=infrastructure,{{ ldaptoolbox_openldap_suffix }}
+uid: syncrepl
+objectClass: simpleSecurityObject
+objectClass: account
+{% if  ldaptoolbox_openldap_syncrepl_password_hash %}
+userPassword: {{ ldaptoolbox_openldap_syncrepl_password_hash }}
+{% else %}
+userPassword: {{ ldaptoolbox_openldap_syncrepl_password_vault }}
+{% endif %}
+# pwdPolicySubentry: cn=dsa,ou=ppolicies,{{ ldaptoolbox_openldap_suffix }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,0 @@
----
-# vars file for ansible-role-ldaptoolbox-openldap
-
-# for centos
-# ldaptoolbox_openldap_olcTLSCACertificateFile: /etc/ssl/certs/ca-bundle.crt

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,5 @@
 ---
 # vars file for ansible-role-ldaptoolbox-openldap
+
+# for centos
+# ldaptoolbox_openldap_olcTLSCACertificateFile: /etc/ssl/certs/ca-bundle.crt


### PR DESCRIPTION
Support rocky / centos / redhat 
Add slapd-cli template
import initial data backup if provided ( ldaptoolbox_openldap_import_data_ldif )
Add syncrepl template to add on top of initial backup 
Add ppolicy template to add on top of initial backup 
Allow to provide localy certificates and keys to distribute
