### PR TITLE
Support for installation on RHEL like target ( and keep Debian too ) #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OpenLDAP
 ========
 
-Ansible role which installs and configures [LTB-Project](https://ltb-project.org/)'s OpenLDAP.
+Ansible role which installs and configures [LTB-Project](https://ltb-project.org/)'s OpenLDAP on Debian and RHEL like targets.
 
 Requirements
 ------------
@@ -9,10 +9,12 @@ Requirements
 - ansible
 - HTTP connection to the LTB-project's repository
 
+Targets OS supported : Debian and RHEL like from version 7.
+
 Role Variables
 --------------
 
-You'll need to store the hash value for you admin passwords. You'll get it like this:
+You'll need to store the hash value for your admin passwords. You'll get it like this:
 
 ```
 /usr/local/openldap/sbin/slappasswd -o module-path="/usr/local/openldap/libexec/openldap" -o module-load="argon2" -h "{ARGON2}" -s "password"
@@ -59,6 +61,23 @@ Run the corresponding task with:
 ansible-playbook tests/monitoring.yml -i tests/inventory
 ```
 
+Test for RHEL
+-------------
+
+here sample of what certificates configuration can be :
+
+```
+ldaptoolbox_openldap_sslgroup=root
+ldaptoolbox_openldap_olcTLSCACertificateFile=/etc/pki/ca-trust/source/anchors/ca-cert.pem
+ldaptoolbox_openldap_olcTLSCertificateFile=/etc/pki/tls/certs/ldaps-cert.pem
+ldaptoolbox_openldap_olcTLSCertificateKeyFile=/etc/pki/tls/private/ldaps.key"
+```
+
+can be run with extra-vars :
+
+```
+ansible-playbook tests/standalone.yml -i tests/inventory --ask-vault-pass --extra-vars "ldaptoolbox_openldap_sslgroup=root ldaptoolbox_openldap_olcTLSCACertificateFile=/etc/pki/ca-trust/source/anchors/ca-cert.pem ldaptoolbox_openldap_olcTLSCertificateFile=/etc/pki/tls/certs/ldaps-cert.pem ldaptoolbox_openldap_olcTLSCertificateKeyFile=/etc/pki/tls/private/ldaps.key"
+```
 
 License
 -------

--- a/tasks/ldaptoolbox-certificates.yml
+++ b/tasks/ldaptoolbox-certificates.yml
@@ -1,0 +1,31 @@
+
+- name: allow ldap to read TLS certificates
+  ansible.builtin.user:
+    name: "{{ ldaptoolbox_openldap_configuration_owner }}"
+    groups: "{{ ldaptoolbox_openldap_sslgroup }}"
+    state: present
+  when: ( ldaptoolbox_openldap_olcTLSCertificateFile )
+
+- name: Ensure correct file ownership, group and permissions for CA
+  ansible.builtin.file:
+    path: "{{ ldaptoolbox_openldap_olcTLSCACertificateFile }}"
+    owner: "root"
+    group: "root"
+    mode: "644"
+  when: ( ldaptoolbox_openldap_olcTLSCACertificateFile )
+
+- name: Ensure correct file ownership, group and permissions for certificate
+  ansible.builtin.file:
+    path: "{{ ldaptoolbox_openldap_olcTLSCertificateFile }}"
+    owner: "root"
+    group: "root"
+    mode: "644"
+  when: ( ldaptoolbox_openldap_olcTLSCertificateFile )
+
+- name: Ensure correct file ownership, group and permissions for key
+  ansible.builtin.file:
+    path: "{{ ldaptoolbox_openldap_olcTLSCertificateKeyFile }}"
+    owner: "root"
+    group: "{{ ldaptoolbox_openldap_sslgroup }}"
+    mode: "640"
+  when: ( ldaptoolbox_openldap_olcTLSCertificateKeyFile )

--- a/tasks/ldaptoolbox-repository.yml
+++ b/tasks/ldaptoolbox-repository.yml
@@ -7,13 +7,37 @@
   - name: fetch repository key
     ansible.builtin.shell: "curl {{ ldaptoolbox_openldap_apt_key_url }} | gpg --dearmor > {{ ldaptoolbox_openldap_apt_keyrings_path }}/{{ ldaptoolbox_openldap_apt_repo_filename }}.gpg"
 
-  - name: add repository
+  - name: add debian repository
     ansible.builtin.apt_repository:
       repo: "{{ ldaptoolbox_openldap_apt_repo }}"
       filename: "{{ ldaptoolbox_openldap_apt_repo_filename }}"
       update_cache: yes
       state: present
-
   when:
   - ansible_os_family == "Debian"
+
+
+- name: centos repository
+  block:
+
+  - name: fetch repository key
+    ansible.builtin.shell: "rpm --import https://ltb-project.org/documentation/_static/RPM-GPG-KEY-LTB-project"
+
+  - name: "setup ldaptoolbox repository on RHEL like version >= 7 "
+    copy:
+      content: |
+        [ltb-project]
+        name=LTB project packages
+        baseurl=https://ltb-project.org/rpm/openldap25/$releasever/$basearch
+        enabled=1
+        gpgcheck=1
+        gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project
+      dest: /etc/yum.repos.d/ltb-project.repo
+  when: ( ansible_os_family == "RedHat" ) and ( ansible_distribution_major_version >= "7" )
+
+
+- name: "unsupported distribution check"
+  ansible.builtin.debug:
+    msg: "Unsupported distribution {{ ansible_distribution }} {{ ansible_distribution_major_version }}"
+  when: not ( (ansible_os_family == "Debian") or ( ( ansible_os_family == "RedHat" ) and ( ansible_distribution_major_version >= "7" ) ) )
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,33 +19,8 @@
     name: "{{ ldaptoolbox_openldap_packages_base }}"
     state: "{{ ldaptoolbox_openldap_packages_state }}"
 
-- name: allow ldap to read TLS certificates
-  ansible.builtin.user:
-    name: "{{ ldaptoolbox_openldap_configuration_owner }}"
-    groups: "{{ ldaptoolbox_openldap_sslgroup }}"
-    state: present
-  when: ldaptoolbox_openldap_olcTLSCertificateFile is defined
-
-- name: Ensure correct file ownership, group and permissions for CA
-  ansible.builtin.file:
-    path: "{{ ldaptoolbox_openldap_olcTLSCACertificateFile }}"
-    owner: "root"
-    group: "root"
-    mode: "644"
-
-- name: Ensure correct file ownership, group and permissions for certificate
-  ansible.builtin.file:
-    path: "{{ ldaptoolbox_openldap_olcTLSCertificateFile }}"
-    owner: "root"
-    group: "root"
-    mode: "644"
-
-- name: Ensure correct file ownership, group and permissions for key
-  ansible.builtin.file:
-    path: "{{ ldaptoolbox_openldap_olcTLSCertificateKeyFile }}"
-    owner: "root"
-    group: "{{ ldaptoolbox_openldap_sslgroup }}"
-    mode: "640"
+- name: setup certificates
+  include_tasks: ldaptoolbox-certificates.yml
 
 # Configuration
 # -------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,8 @@
   package:
     name: "{{ ldaptoolbox_openldap_packages_dependencies }}"
     state: "{{ ldaptoolbox_openldap_packages_state }}"
+  when:
+  - ansible_os_family == "Debian"
 
 - name: install ldaptoolbox repository
   include_tasks: ldaptoolbox-repository.yml

--- a/templates/var/backups/openldap/config.ldif
+++ b/templates/var/backups/openldap/config.ldif
@@ -26,12 +26,16 @@ olcServerID: {{ ldaptoolbox_openldap_olcServerID }}
 olcSockbufMaxIncoming: 262143
 olcSockbufMaxIncomingAuth: 16777215
 olcThreads: 16
+{% if ldaptoolbox_openldap_olcTLSCACertificateFile %}
 olcTLSCACertificateFile: {{ ldaptoolbox_openldap_olcTLSCACertificateFile }}
-olcTLSCertificateFile:  {{ ldaptoolbox_openldap_olcTLSCertificateFile }}
-olcTLSCertificateKeyFile: {{ ldaptoolbox_openldap_olcTLSCertificateKeyFile }}
 olcTLSCRLCheck: none
 olcTLSVerifyClient: allow
+{% endif %}
+{% if ldaptoolbox_openldap_olcTLSCertificateFile %}
 olcTLSProtocolMin: {{ ldaptoolbox_openldap_olcTLSProtocolMin }}
+olcTLSCertificateFile:  {{ ldaptoolbox_openldap_olcTLSCertificateFile }}
+olcTLSCertificateKeyFile: {{ ldaptoolbox_openldap_olcTLSCertificateKeyFile }}
+{% endif %}
 olcToolThreads: 1
 olcWriteTimeout: 0
 olcLogLevel: {{ ldaptoolbox_openldap_olcLogLevel }}


### PR DESCRIPTION
- Add supported targets and update README with RHEL support.
- move certificate setup task in a dedicated file
- update backup template with removal of optional cert related values if not provided
- fix oclcSyncrepl typo missing " after tls_key= in backup template